### PR TITLE
(MODULES-5405) add heredoc and interp detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ This plugin provides a new check to `puppet-lint`. It will detect functions that
 ### Before and after
 
 For example the following puppet code does not wrap the message
-```ruby
+```puppet
 warning('message')
 ```
 wrapping the message then looks like
-```ruby
+```puppet
 warning(translate('message'))
 ```
 
@@ -41,19 +41,40 @@ This tells you which file and what line the infringement occurred, as well as th
 + Multiline strings
 
 **BAD**
-```ruby
+```puppet
 warning(translate('to be or') / 
 translate('not to be'))
 ```
 
 **GOOD**
-```ruby
+```puppet
 warning(translate('to be or not to be')
 ```
 
 + Concatenated strings
 + Heredoc strings
+
+The :HEREDOC_OPEN token (`@(EOL)`) should be the only part passed to the `translate()` function. Do not pass the entire heredoc.
+
+**BAD**
+```puppet
+warning(translate(@(EOL)
+  This is a heredoc.
+  It's lovely. 
+  | EOL))
+```
+
+**GOOD**
+```puppet
+warning(translate(@(EOL))
+  This is a heredoc.
+  It's lovely. 
+  | EOL)
+```
+
 + Interpolated strings
+
+_Interpolated strings are not supported at this time and will not be decorated with the fix option._
 
 ### Fix issues automatically
 

--- a/lib/puppet-lint/plugins/check_i18n.rb
+++ b/lib/puppet-lint/plugins/check_i18n.rb
@@ -6,16 +6,37 @@ PuppetLint.new_check(:check_i18n) do
     tokens.select { |token| FUNCTIONS_TO_BE_DECORATED.include?(token.value) && function?(token) && message_not_decorated?(token) }.each do |token|
       function = token.value
       non_decorated_message = token.next_token.next_token
-      notify :warning, message: "'#{function}' messages should be decorated: eg #{TRANSLATE_FUNCTION}(#{non_decorated_message.value})",
+
+      interpolation = interpolation? non_decorated_message
+      heredoc = heredoc? non_decorated_message
+
+      message = if interpolation
+                  "#{function}(#{non_decorated_message.value}) should be decorated but interpolation is not supported at this time."
+                elsif heredoc
+                  "'#{function}' messages should be decorated: eg #{TRANSLATE_FUNCTION}(#{non_decorated_message.value}) heredoc detected."
+                else
+                  "'#{function}' messages should be decorated: eg #{TRANSLATE_FUNCTION}(#{non_decorated_message.value})"
+                end
+
+      notify :warning, message: message,
                        line: token.line,
                        column: non_decorated_message.column,
-                       token: non_decorated_message
+                       token: non_decorated_message,
+                       interpolation: interpolation,
+                       heredoc: heredoc
     end
   end
 
   def fix(problem)
+    return if problem[:interpolation]
+
     left_index = tokens.index(problem[:token])
-    right_index = tokens.index(problem[:token].find_token_of(:next, :RPAREN, skip_blocks: true))
+    right_index = if problem[:heredoc]
+                    tokens.index(problem[:token].find_token_of(:next, :NEWLINE, skip_blocks: true) || problem[:token].find_token_of(:next, :WHITESPACE, skip_blocks: true))
+                  else
+                    tokens.index(problem[:token].find_token_of(:next, :RPAREN, skip_blocks: true))
+                  end
+
     # order of insertion is important, we insert right to left, so as not to muddy the indexing
     tokens.insert(right_index, PuppetLint::Lexer::Token.new(:RPAREN, ')', 0, 0))
     tokens.insert(left_index, PuppetLint::Lexer::Token.new(:NAME, TRANSLATE_FUNCTION, 0, 0))
@@ -30,5 +51,13 @@ PuppetLint.new_check(:check_i18n) do
     # the next token is the openning round brace so grab the next
     suspected_i18n_function = token.next_token.next_token
     suspected_i18n_function.value != TRANSLATE_FUNCTION
+  end
+
+  def interpolation?(token)
+    token.type == :DQPRE
+  end
+
+  def heredoc?(token)
+    token.type == :HEREDOC_OPEN
   end
 end

--- a/spec/puppet-lint/plugins/check_i18n_spec.rb
+++ b/spec/puppet-lint/plugins/check_i18n_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe 'check_i18n' do
   let(:msg) { "'warning' messages should be decorated: eg translate(message)" }
+  let(:int_msg) { %r{interpolation is not supported} }
+  let(:here_msg) { %r{heredoc detected} }
 
   context 'with fix disabled' do
     context 'function without translate function' do
@@ -13,6 +15,58 @@ describe 'check_i18n' do
 
       it 'creates a warning' do
         expect(problems).to contain_warning(msg).on_line(1).in_column(9)
+      end
+    end
+
+    context 'with ${} interpolation' do
+      let(:code) { 'warning("a message: ${message}")' }
+
+      it 'detects a problem' do
+        expect(problems).to have(1).problems
+      end
+
+      it 'creates warning' do
+        expect(problems[0][:message]).to match(int_msg)
+      end
+
+      it 'expects problem[:interpolation] to be true' do
+        expect(problems[0][:interpolation]).to be_truthy
+      end
+    end
+
+    context 'with $ interpolation' do
+      let(:code) { 'warning("a message: $message")' }
+
+      it 'detects a problem' do
+        expect(problems).to have(1).problems
+      end
+
+      it 'creates warning' do
+        expect(problems[0][:message]).to match(int_msg)
+      end
+
+      it 'expects problem[:interpolation] to be true' do
+        expect(problems[0][:interpolation]).to be_truthy
+      end
+    end
+
+    context 'with a heredoc' do
+      let(:code) do
+        'warning(@(EOL)
+       this is a heredoc
+       | EOL)'
+      end
+
+      it 'detects something' do
+        expect(problems).to have(1).problems
+      end
+
+      it 'creates warning' do
+        expect(problems[0][:message]).to match(here_msg)
+      end
+
+      it 'expects problem[:heredoc] to be true' do
+        expect(problems[0][:heredoc]).to be_truthy
       end
     end
 
@@ -47,6 +101,34 @@ describe 'check_i18n' do
 
       it 'adds a newline to the end of the manifest' do
         expect(manifest).to eq("warning(translate('message'))")
+      end
+    end
+
+    context 'function without a translate function with interpolation' do
+      let(:code) { 'warning("a message: ${message}")' }
+
+      it 'onlies detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'adds a newline to the end of the manifest' do
+        expect(manifest).not_to eq("warning(translate('message'))")
+      end
+    end
+
+    context 'function without a translate function with a heredoc' do
+      let(:code) do
+        'warning(@(EOL)
+       heredoc
+       | EOL)'
+      end
+
+      it 'onlies detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'decorates the heredoc appropriately' do
+        expect(manifest).to match(%r{warning\(translate\(@\(EOL\)\)})
       end
     end
 


### PR DESCRIPTION
This adds detection for here heredocs and interpolation in strings not already decorated. If it finds an undecorated string with interpolation, it skips over it. If it finds an undecorated string with heredoc, it decorates the heredoc tag simliar to the way they're decorated in ruby. We may also want to check for these things in already decorated strings as a warning to say 'hey, you've decorated this but its not going to work because youve got interpolation in there'.